### PR TITLE
Development/jamie/nuget

### DIFF
--- a/make/endor.mk
+++ b/make/endor.mk
@@ -329,7 +329,7 @@ endor-check: $(ENDOR_IPK)
 # This builds the endor service test binaries
 #
 endor-service-tests:
-	msbuild -t:restore -p:RestorePackagesPath=$(ENDOR_BUILD_DIR)/Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries
+	(cd $(ENDOR_BUILD_DIR)/OptWare/Make; msbuild -t:restore -p:RestorePackagesPath=../../Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries)
 	$(ENDOR_BUILD_DIR)/OptWare/Make/endor-makefile service-tests $(BUILD_DIR) $(ENDOR_PRODUCT)
 
 endor-service-tests-clean:

--- a/make/endor.mk
+++ b/make/endor.mk
@@ -329,7 +329,7 @@ endor-check: $(ENDOR_IPK)
 # This builds the endor service test binaries
 #
 endor-service-tests:
-	msbuild -t:restore -p:RestorePackagesPath=$(ENDOR_BUILD_DIR)/Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries;
+	msbuild -t:restore -p:RestorePackagesPath=$(ENDOR_BUILD_DIR)/Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries
 	$(ENDOR_BUILD_DIR)/OptWare/Make/endor-makefile service-tests $(BUILD_DIR) $(ENDOR_PRODUCT)
 
 endor-service-tests-clean:

--- a/make/endor.mk
+++ b/make/endor.mk
@@ -329,6 +329,7 @@ endor-check: $(ENDOR_IPK)
 # This builds the endor service test binaries
 #
 endor-service-tests:
+	msbuild -t:restore -p:RestorePackagesPath=$(ENDOR_BUILD_DIR)/Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries;
 	$(ENDOR_BUILD_DIR)/OptWare/Make/endor-makefile service-tests $(BUILD_DIR) $(ENDOR_PRODUCT)
 
 endor-service-tests-clean:

--- a/make/endor.mk
+++ b/make/endor.mk
@@ -329,7 +329,7 @@ endor-check: $(ENDOR_IPK)
 # This builds the endor service test binaries
 #
 endor-service-tests:
-	(cd $(ENDOR_BUILD_DIR)/OptWare/Make; msbuild -t:restore -p:RestorePackagesPath=../../Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries)
+	(cd $(ENDOR_BUILD_DIR); msbuild -t:restore -p:RestorePackagesPath=Libs/CAT/Calnex.Endor.DataStorage/Calnex.Common/Libraries)
 	$(ENDOR_BUILD_DIR)/OptWare/Make/endor-makefile service-tests $(BUILD_DIR) $(ENDOR_PRODUCT)
 
 endor-service-tests-clean:


### PR DESCRIPTION
Merging in change to endor makefile to run nuget package restore before building service tests. Service tests sometimes run on a seperate build node from endor applications, so the running only before building endor was not sufficient.