### PR TITLE
Development/jamie/perist logs

### DIFF
--- a/sources/optware-bootstrap/optware
+++ b/sources/optware-bootstrap/optware
@@ -32,15 +32,16 @@ case "$1" in
         [ -x /etc/init.d/S90fix-interfaces ] && /etc/init.d/S90fix-interfaces
 
         if test -b /dev/vda; then 
+            echo "Mounting persistent log directory /dev/vda1"
             mkdir -p /home/calnex/Calnex100G/Persist; 
             chown calnex:calnex /home/calnex/Calnex100G/Persist
-            echo "Mounting persistent log directory /dev/vda1"
             mount /dev/vda1 /home/calnex/Calnex100G/Persist; 
+
+            echo "Linking LogFiles directory to persistent log directory"
             if test -d /home/calnex/Calnex100G/Logs/LogFiles/; then
-                mv /home/calnex/Calnex100G/Logs/LogFiles /home/calnex/Calnex100G/Persist
-            else
-                mkdir -p /home/calnex/Calnex100G/Persist/LogFiles
+                rm -rf /home/calnex/Calnex100G/Logs/LogFiles
             fi
+            su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Persist/LogFiles'
             su - calnex -c 'ln -s /home/calnex/Calnex100G/Persist/LogFiles /home/calnex/Calnex100G/Logs/LogFiles'
         fi
 

--- a/sources/optware-bootstrap/optware
+++ b/sources/optware-bootstrap/optware
@@ -36,6 +36,12 @@ case "$1" in
             chown calnex:calnex /home/calnex/Calnex100G/Persist
             echo "Mounting persistent log directory /dev/vda1"
             mount /dev/vda1 /home/calnex/Calnex100G/Persist; 
+            if test -d /home/calnex/Calnex100G/Logs/LogFiles/; then
+                mv /home/calnex/Calnex100G/Logs/LogFiles /home/calnex/Calnex100G/Persist
+            else
+                mkdir -p /home/calnex/Calnex100G/Persist/LogFiles
+            fi
+            su - calnex -c 'ln -s /home/calnex/Calnex100G/Persist/LogFiles /home/calnex/Calnex100G/Logs/LogFiles'
         fi
 
         [ -x /opt/etc/rc.optware ] && su - calnex -c '/opt/etc/rc.optware start'

--- a/sources/optware-bootstrap/optware
+++ b/sources/optware-bootstrap/optware
@@ -30,9 +30,13 @@ case "$1" in
         fi
 
         [ -x /etc/init.d/S90fix-interfaces ] && /etc/init.d/S90fix-interfaces
-        mkdir -p /home/calnex/Calnex100G/Persist
-        chown calnex:calnex /home/calnex/Calnex100G/Persist
-        echo "/dev/vda1	/home/calnex/Calnex100G/Persist	ext4	defaults	0	2" >> /etc/fstab;
+
+        if test -b /dev/vda; then 
+            mkdir -p /home/calnex/Calnex100G/Persist; 
+            chown calnex:calnex /home/calnex/Calnex100G/Persist
+            echo "Mounting persistent log directory /dev/vda1"
+            mount /dev/vda1 /home/calnex/Calnex100G/Persist; 
+        fi
 
         [ -x /opt/etc/rc.optware ] && su - calnex -c '/opt/etc/rc.optware start'
         ;;

--- a/sources/optware-bootstrap/optware
+++ b/sources/optware-bootstrap/optware
@@ -31,7 +31,7 @@ case "$1" in
 
         [ -x /etc/init.d/S90fix-interfaces ] && /etc/init.d/S90fix-interfaces
 
-        if test -b /dev/vda; then 
+        if test -b /dev/vda && ! test -d /home/calnex/Calnex100G/Persist; then 
             echo "Mounting persistent log directory /dev/vda1"
             mkdir -p /home/calnex/Calnex100G/Persist; 
             chown calnex:calnex /home/calnex/Calnex100G/Persist
@@ -42,6 +42,7 @@ case "$1" in
                 rm -rf /home/calnex/Calnex100G/Logs/LogFiles
             fi
             su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Persist/LogFiles'
+            su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Logs'
             su - calnex -c 'ln -s /home/calnex/Calnex100G/Persist/LogFiles /home/calnex/Calnex100G/Logs/LogFiles'
         fi
 

--- a/sources/optware-bootstrap/optware
+++ b/sources/optware-bootstrap/optware
@@ -15,29 +15,33 @@ case "$1" in
             fi
         fi
 	
-	# Default repo location to network
-	echo "src/gz local file://srv/tftp/optware"       > /opt/etc/ipkg/cross-feed.conf
-	
-	# Call USB script, it should make no change
-	# if no USB is present
-	/bin/optwareUSB add
-	
-	if [ -x /etc/init.d/S00SystemConfiguration ]; then
-		/etc/init.d/S00SystemConfiguration
-	fi
-	if [ -x /etc/init.d/S00SystemLoading ]; then
-		/etc/init.d/S00SystemLoading start
-	fi
+        # Default repo location to network
+        echo "src/gz local file://srv/tftp/optware"       > /opt/etc/ipkg/cross-feed.conf
+        
+        # Call USB script, it should make no change
+        # if no USB is present
+        /bin/optwareUSB add
+        
+        if [ -x /etc/init.d/S00SystemConfiguration ]; then
+            /etc/init.d/S00SystemConfiguration
+        fi
+        if [ -x /etc/init.d/S00SystemLoading ]; then
+            /etc/init.d/S00SystemLoading start
+        fi
 
-	[ -x /etc/init.d/S90fix-interfaces ] && /etc/init.d/S90fix-interfaces
-	[ -x /opt/etc/rc.optware ] && su - calnex -c '/opt/etc/rc.optware start'
-    ;;
+        [ -x /etc/init.d/S90fix-interfaces ] && /etc/init.d/S90fix-interfaces
+        mkdir -p /home/calnex/Calnex100G/Persist
+        chown calnex:calnex /home/calnex/Calnex100G/Persist
+        echo "/dev/vda1	/home/calnex/Calnex100G/Persist	ext4	defaults	0	2" >> /etc/fstab;
+
+        [ -x /opt/etc/rc.optware ] && su - calnex -c '/opt/etc/rc.optware start'
+        ;;
     reconfig)
-	true
+        true
     ;;
     stop)
         echo "Shutting down Optware."
-	true
+	    true
     ;;
     *)
         echo "Usage: $0 {start|stop|reconfig}"

--- a/sources/optware-bootstrap/optware
+++ b/sources/optware-bootstrap/optware
@@ -38,12 +38,12 @@ case "$1" in
             mount /dev/vda1 /home/calnex/Calnex100G/Persist; 
 
             echo "Linking LogFiles directory to persistent log directory"
-            if test -d /home/calnex/Calnex100G/Logs/LogFiles/; then
-                rm -rf /home/calnex/Calnex100G/Logs/LogFiles
+            if test -d /home/calnex/Calnex100G/Logs/; then
+                rm -rf /home/calnex/Calnex100G/Logs
             fi
-            su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Persist/LogFiles'
-            su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Logs'
-            su - calnex -c 'ln -s /home/calnex/Calnex100G/Persist/LogFiles /home/calnex/Calnex100G/Logs/LogFiles'
+            #su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Persist'
+            #su - calnex -c 'mkdir -p /home/calnex/Calnex100G/Logs'
+            su - calnex -c 'ln -s /home/calnex/Calnex100G/Persist /home/calnex/Calnex100G/Logs'
         fi
 
         [ -x /opt/etc/rc.optware ] && su - calnex -c '/opt/etc/rc.optware start'


### PR DESCRIPTION
Merge of changes that allow nightly testing VM's to have persistent logs across reboots, this is to allow debugging of failures that cause the VM to reboot multiple times before the testing is finished which make logs associated with the failures unattainable. Nightly VM's now have a persistent store mounted to /home/calnex/Calnex100G/Persist